### PR TITLE
Added callbackComplete to FileSystem._openWriteStream, as well as logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "description": "WebDAV Server",
   "dependencies": {
     "mime-types": "^2.1.18",
+    "winston": "^3.3.3",
     "xml-js-builder": "^1.0.3"
   },
   "devDependencies": {

--- a/src/helper/v2/logger.ts
+++ b/src/helper/v2/logger.ts
@@ -1,0 +1,124 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as winston from 'winston';
+import * as path from 'path';
+import * as fs from 'fs';
+
+let logger: winston.Logger;
+export enum LS { // logger section
+    eAUDIT, // audit
+    eAUTH,  // authentication
+    eCACHE, // cache
+    eCOLL,  // collections
+    eCONF,  // config
+    eDB,    // database
+    eEVENT, // event
+    eGQL,   // graphql
+    eHTTP,  // http
+    eJOB,   // job
+    eMETA,  // metadata
+    eNAV,   // navigation
+    eRPT,   // report
+    eSTR,   // storage
+    eSYS,   // system/utilities
+    eTEST,  // test code
+    eWD,    // webdav
+    eWF,    // workflow
+    eNONE,  // none specified ... don't use this!
+}
+
+export function info(message: string, eLogSection: LS = LS.eWD): void {
+    logger.info(message, { eLS: eLogSection });
+}
+
+export function error(message: string, eLogSection: LS = LS.eWD, obj: any | null = null): void {
+    if (obj && typeof obj === 'object' && obj !== null) {
+        obj.eLS = eLogSection;
+        logger.error(message, obj);
+    } else
+        logger.error(message, { eLS: eLogSection });
+}
+
+function loggerSectionName(eLogSection: LS | undefined): string {
+    switch (eLogSection) {
+        case LS.eAUDIT: return 'AUD';
+        case LS.eAUTH:  return 'ATH';
+        case LS.eCACHE: return 'CCH';
+        case LS.eCOLL:  return 'COL';
+        case LS.eCONF:  return 'CNF';
+        case LS.eDB:    return 'DB ';
+        case LS.eEVENT: return 'EVE';
+        case LS.eGQL:   return 'GQL';
+        case LS.eHTTP:  return 'HTP';
+        case LS.eJOB:   return 'JOB';
+        case LS.eMETA:  return 'MET';
+        case LS.eNAV:   return 'NAV';
+        case LS.eRPT:   return 'RPT';
+        case LS.eSTR:   return 'STR';
+        case LS.eSYS:   return 'SYS';
+        case LS.eTEST:  return 'tst';
+        case LS.eWD:    return 'WDV';
+        case LS.eWF:    return 'WF ';
+        case LS.eNONE:  return '***';
+        default:        return '***';
+    }
+}
+
+function configureLogger(logPath: string | null): void {
+    /* istanbul ignore if */
+    if (logger)
+        return;
+
+    /* istanbul ignore else */
+    if (!logPath)
+        logPath = './var/logs';
+
+    logger = winston.createLogger({
+        level: 'verbose',
+        format: winston.format.combine(
+            winston.format.errors({ stack: true }), // emit stack trace when Error objects are passed in
+            winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSS' }),
+            // winston.format.colorize(),
+            // winston.format.json()
+            // winston.format.simple(),
+            winston.format.printf((info) => {
+                const reqID: string = ' --- ';
+                const userID: string = '---';
+
+                const logSection: string = loggerSectionName(info.eLS);
+                const stack: string = info.stack ? `\n${info.stack}` : '';
+                return `${info.timestamp} [${reqID}] U${userID} ${logSection} ${info.level}: ${info.message}${stack}`;
+            })
+        ),
+        transports: [
+            new winston.transports.File({
+                filename: path.join(logPath, 'WebDAVCombined.log'),
+                maxsize: 10485760 // 10MB
+            }),
+            new winston.transports.File({
+                filename: path.join(logPath, 'WebDAVError.log'),
+                level: 'error',
+                maxsize: 10485760 // 10MB
+            }),
+        ]
+    });
+
+    // For the time being, let's emit logs to the Console in production, for use in debugging
+    // /* istanbul ignore else */
+    // if (process.env.NODE_ENV !== 'production') {
+    logger.add(new winston.transports.Console());
+    // }
+
+    try {
+        /* istanbul ignore if */
+        if (!fs.existsSync(logPath))
+            fs.mkdirSync(logPath);
+    } catch (error) /* istanbul ignore next */ {
+        logger.error(error);
+    }
+
+    info('**************************', LS.eSYS);
+    info(`Writing logs to ${path.resolve(logPath)}`, LS.eSYS);
+}
+
+configureLogger(null);

--- a/src/manager/v2/fileSystem/FileSystem.ts
+++ b/src/manager/v2/fileSystem/FileSystem.ts
@@ -611,7 +611,8 @@ export abstract class FileSystem implements ISerializableFileSystem
      * @param callback Returns the stream.
      */
     openWriteStream(ctx : RequestContext, path : Path | string, mode : OpenWriteStreamMode, targetSource : boolean, estimatedSize : number, callback : Return2Callback<Writable, boolean>) : void
-    openWriteStream(ctx : RequestContext, _path : Path | string, _mode : OpenWriteStreamMode | boolean | number | Return2Callback<Writable, boolean>, _targetSource ?: boolean | number | Return2Callback<Writable, boolean>, _estimatedSize ?: number | Return2Callback<Writable, boolean>, _callback ?: Return2Callback<Writable, boolean>) : void
+    openWriteStream(ctx : RequestContext, path : Path | string, mode : OpenWriteStreamMode, targetSource : boolean, estimatedSize : number, callback : Return2Callback<Writable, boolean>, callbackComplete : SimpleCallback) : void
+    openWriteStream(ctx : RequestContext, _path : Path | string, _mode : OpenWriteStreamMode | boolean | number | Return2Callback<Writable, boolean>, _targetSource ?: boolean | number | Return2Callback<Writable, boolean>, _estimatedSize ?: number | Return2Callback<Writable, boolean>, _callback ?: Return2Callback<Writable, boolean>, _callbackComplete?: SimpleCallback) : void
     {
         let targetSource = false;
         for(const obj of [ _mode, _targetSource ])
@@ -655,7 +656,7 @@ export abstract class FileSystem implements ISerializableFileSystem
                         estimatedSize,
                         targetSource,
                         mode
-                    }, (e, wStream) => callback(e, wStream, created));
+                    }, (e, wStream) => callback(e, wStream, created), _callbackComplete);
                 }
                 const go = (callback : Return2Callback<Writable, boolean>) =>
                 {
@@ -748,7 +749,7 @@ export abstract class FileSystem implements ISerializableFileSystem
             })
         })
     }
-    protected _openWriteStream?(path : Path, ctx : OpenWriteStreamInfo, callback : ReturnCallback<Writable>) : void
+    protected _openWriteStream?(path : Path, ctx : OpenWriteStreamInfo, callback : ReturnCallback<Writable>, callbackComplete: SimpleCallback) : void
     
     /**
      * Open a stream to read the content of the resource.
@@ -2027,9 +2028,13 @@ export abstract class FileSystem implements ISerializableFileSystem
                 .each(Object.keys(tree), (name, cb) => {
                     const value = tree[name];
                     const childPath = rootPath.getChildPath(name);
-                    if(value.constructor === ResourceType || value.constructor === String || value.constructor === Buffer)
+                    if(value.constructor === ResourceType || value.constructor === Buffer)
                     {
                         this.addSubTree(ctx, childPath, value, cb)
+                    }
+                    else if(value.constructor === String)
+                    {
+                        this.addSubTree(ctx, childPath, value as string, cb)
                     }
                     else
                     {

--- a/src/manager/v2/fileSystem/Resource.ts
+++ b/src/manager/v2/fileSystem/Resource.ts
@@ -30,7 +30,8 @@ export class Resource
     {
         this.fs.delete(this.context, this.path, _depth, _callback);
     }
-    
+
+    /*
     openWriteStream(callback : Return2Callback<Writable, boolean>) : void
     openWriteStream(estimatedSize : number, callback : Return2Callback<Writable, boolean>) : void
     openWriteStream(targetSource : boolean, callback : Return2Callback<Writable, boolean>) : void
@@ -38,10 +39,11 @@ export class Resource
     openWriteStream(mode : OpenWriteStreamMode, callback : Return2Callback<Writable, boolean>) : void
     openWriteStream(mode : OpenWriteStreamMode, estimatedSize : number, callback : Return2Callback<Writable, boolean>) : void
     openWriteStream(mode : OpenWriteStreamMode, targetSource : boolean, callback : Return2Callback<Writable, boolean>) : void
-    openWriteStream(mode : OpenWriteStreamMode, targetSource : boolean, estimatedSize : number, callback : Return2Callback<Writable, boolean>) : void
     openWriteStream(_mode : any, _targetSource ?: any, _estimatedSize ?: any, _callback ?: Return2Callback<Writable, boolean>) : void
+    */
+    openWriteStream(mode : OpenWriteStreamMode, targetSource : boolean, estimatedSize : number, callback : Return2Callback<Writable, boolean>, callbackComplete: SimpleCallback) : void
     {
-        this.fs.openWriteStream(this.context, this.path, _mode, _targetSource, _estimatedSize, _callback);
+        this.fs.openWriteStream(this.context, this.path, mode, targetSource, estimatedSize, callback, callbackComplete);
     }
 
     openReadStream(callback : ReturnCallback<Readable>) : void

--- a/src/resource/v1/physical/PhysicalGateway.ts
+++ b/src/resource/v1/physical/PhysicalGateway.ts
@@ -16,7 +16,7 @@ export class PhysicalGateway extends PhysicalFolder
         [path : string] : PhysicalResource
     }
 
-    constructor(rootPath : string, protected customName ?: string, parent ?: IResource, fsManager ?: FSManager)
+    constructor(rootPath : string, public customName ?: string, parent ?: IResource, fsManager ?: FSManager)
     {
         super(rootPath, parent, fsManager ? fsManager : new PhysicalGFSManager());
 

--- a/src/server/v2/webDAVServer/StartStop.ts
+++ b/src/server/v2/webDAVServer/StartStop.ts
@@ -1,6 +1,7 @@
 import { HTTPCodes, HTTPRequestContext, HTTPMethod } from '../WebDAVRequest'
 import { WebDAVServerStartCallback } from './WebDAVServer'
 import { Errors } from '../../../Errors'
+import * as LOG from '../../../helper/v2/logger';
 import * as https from 'https'
 import * as http from 'http'
 
@@ -23,6 +24,7 @@ export function executeRequest(req : http.IncomingMessage, res : http.ServerResp
 
         base.exit = () =>
         {
+            LOG.info(`StartStop executeRequest exit ${req.method}`);
             base.response.end();
             this.invokeAfterRequest(base, null);
         };
@@ -58,6 +60,10 @@ export function executeRequest(req : http.IncomingMessage, res : http.ServerResp
         }
         else
         {
+            LOG.info(`StartStop executeRequest ${req.method}`);
+            // if (req.method.toLowerCase() === 'put')
+            //     LOG.info(`StartStop executeRequest PUT has body ${JSON.stringify(req['body'])}`, LOG.LS.eHTTP);
+
             this.invokeBeforeRequest(base, () => {
                 method.chunked(base, req, base.exit);
             })

--- a/src/server/v2/webDAVServer/WebDAVServer.ts
+++ b/src/server/v2/webDAVServer/WebDAVServer.ts
@@ -18,6 +18,7 @@ import * as https from 'https'
 import * as http from 'http'
 import { promisifyCall } from '../../../helper/v2/promise'
 import { SerializedData, FileSystemSerializer } from '../../../manager/v2/export'
+import * as LOG from '../../../helper/v2/logger';
 
 export type WebDAVServerStartCallback = (server ?: http.Server) => void;
 
@@ -45,6 +46,8 @@ export class WebDAVServer
 
     constructor(options ?: WebDAVServerOptions)
     {
+        LOG.info('WebDAVServer.constructor');
+
         this.beforeManagers = [];
         this.afterManagers = [];
         this.methods = {};


### PR DESCRIPTION
WebDAV:
* Extended FileSystem's openWriteStream to take a callbackComplete function.  The framework passes the callbackComplete method, allowing the implementer to tell the framework when writing is actually complete (instead of using the write stream's onFInish event) -- writing may involve subsequent, time-consuming operations.
* Updated PUT command to provide a callbackComplete() to _openWriteStream(), which results in either an HTTP OK or InternalServerError.

Build:
* Added logging support via winston
* Fixed some build errors